### PR TITLE
カレンダー表示【ログイン後、ユーザー】(feature/issue-#1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,9 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
-gem 'jquery-rails', '4.3.3'
 gem 'fullcalendar-rails'
 gem 'momentjs-rails'
+gem 'jquery-rails'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ DEPENDENCIES
   devise
   fullcalendar-rails
   jbuilder (~> 2.5)
-  jquery-rails (= 4.3.3)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   momentjs-rails
   pg (>= 0.18, < 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,16 +1,32 @@
-// This is a manifest file that'll be compiled into application.js, which will include all the files
-// listed below.
-//
-// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's
-// vendor/assets/javascripts directory can be referenced here using a relative path.
-//
-// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
-// compiled file. JavaScript code in this file should be added after the last require_* statement.
-//
-// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
-// about supported directives.
-//
-//= require rails-ujs
-//= require activestorage
-//= require turbolinks
-//= require_tree .
+//= require jquery
+//= require moment
+//= require fullcalendar
+//= require fullcalendar/lang/ja
+
+$(document).ready(function() {
+  $("#calendar").fullCalendar({});
+});
+
+$(function() {
+  // 画面遷移を検知
+  $(document).on("turbolinks:load", function() {
+    // lengthを呼び出すことで、#calendarが存在していた場合はtrueの処理がされ、無い場合はnillを返す
+    if ($("#calendar").length) {
+      function eventCalendar() {
+        return $("#calendar").fullCalendar({});
+      }
+      function clearCalendar() {
+        $("#calendar").html("");
+      }
+
+      $(document).on("turbolinks:load", function() {
+        eventCalendar();
+      });
+      $(document).on("turbolinks:before-cache", clearCalendar);
+
+      $("#calendar").fullCalendar({
+        events: "/events.json"
+      });
+    }
+  });
+});

--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -1,0 +1,10 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/
+$(document).on 'turbolinks:load', ->
+  $('#calendar').fullCalendar {}
+  return
+
+$(document).on 'turbolinks:before-cache', ->
+  $('#calendar').empty()
+  return

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,5 @@
  *
  *= require_tree .
  *= require_self
+ *= require fullcalendar
  */

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,74 @@
+class EventsController < ApplicationController
+  before_action :set_event, only: [:show, :edit, :update, :destroy]
+
+  # GET /events
+  # GET /events.json
+  def index
+    @events = Event.all
+  end
+
+  # GET /events/1
+  # GET /events/1.json
+  def show
+  end
+
+  # GET /events/new
+  def new
+    @event = Event.new
+  end
+
+  # GET /events/1/edit
+  def edit
+  end
+
+  # POST /events
+  # POST /events.json
+  def create
+    @event = Event.new(event_params)
+
+    respond_to do |format|
+      if @event.save
+        format.html { redirect_to @event, notice: 'Event was successfully created.' }
+        format.json { render :show, status: :created, location: @event }
+      else
+        format.html { render :new }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /events/1
+  # PATCH/PUT /events/1.json
+  def update
+    respond_to do |format|
+      if @event.update(event_params)
+        format.html { redirect_to @event, notice: 'Event was successfully updated.' }
+        format.json { render :show, status: :ok, location: @event }
+      else
+        format.html { render :edit }
+        format.json { render json: @event.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /events/1
+  # DELETE /events/1.json
+  def destroy
+    @event.destroy
+    respond_to do |format|
+      format.html { redirect_to events_url, notice: 'Event was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_event
+      @event = Event.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def event_params
+      params.require(:event).permit(:title, :description, :start_date, :end_date)
+    end
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/views/events/_event.json.jbuilder
+++ b/app/views/events/_event.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! event, :id, :title, :description, :start_date, :end_date, :created_at, :updated_at
+json.url event_url(event, format: :json)

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_with(model: event, local: true) do |form| %>
+  <% if event.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(event.errors.count, "error") %> prohibited this event from being saved:</h2>
+
+      <ul>
+      <% event.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :description %>
+    <%= form.text_area :description %>
+  </div>
+
+  <div class="field">
+    <%= form.label :start_date %>
+    <%= form.datetime_select :start_date %>
+  </div>
+
+  <div class="field">
+    <%= form.label :end_date %>
+    <%= form.datetime_select :end_date %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Show', @event %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Events</h1>
+<div id="calendar"></div>
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Start date</th>
+      <th>End date</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event.title %></td>
+        <td><%= event.description %></td>
+        <td><%= event.start_date %></td>
+        <td><%= event.end_date %></td>
+        <td><%= link_to 'Show', event %></td>
+        <td><%= link_to 'Edit', edit_event_path(event) %></td>
+        <td><%= link_to 'Destroy', event, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Event', new_event_path %>

--- a/app/views/events/index.json.jbuilder
+++ b/app/views/events/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @events, partial: "events/event", as: :event
+json.array!(@events) do |event|
+  json.extract! event, :id, :title, :description
+  json.start event.start_date
+  json.end event.end_date
+  json.url event_url(event, format: :html)
+end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Event</h1>
+
+<%= render 'form', event: @event %>
+
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @event.title %>
+</p>
+
+<p>
+  <strong>Description:</strong>
+  <%= @event.description %>
+</p>
+
+<p>
+  <strong>Start date:</strong>
+  <%= @event.start_date %>
+</p>
+
+<p>
+  <strong>End date:</strong>
+  <%= @event.end_date %>
+</p>
+
+<%= link_to 'Edit', edit_event_path(@event) %> |
+<%= link_to 'Back', events_path %>

--- a/app/views/events/show.json.jbuilder
+++ b/app/views/events/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "events/event", event: @event

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
+  resources :events
   devise_for :users
-  resources :users
   root 'home#top'
 
 end

--- a/db/migrate/20191227072526_create_events.rb
+++ b/db/migrate/20191227072526_create_events.rb
@@ -1,0 +1,12 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.string :title
+      t.text :description
+      t.datetime :start_date
+      t.datetime :end_date
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_27_045203) do
+ActiveRecord::Schema.define(version: 2019_12_27_072526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @event = events(:one)
+  end
+
+  test "should get index" do
+    get events_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_event_url
+    assert_response :success
+  end
+
+  test "should create event" do
+    assert_difference('Event.count') do
+      post events_url, params: { event: { description: @event.description, end_date: @event.end_date, start_date: @event.start_date, title: @event.title } }
+    end
+
+    assert_redirected_to event_url(Event.last)
+  end
+
+  test "should show event" do
+    get event_url(@event)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_event_url(@event)
+    assert_response :success
+  end
+
+  test "should update event" do
+    patch event_url(@event), params: { event: { description: @event.description, end_date: @event.end_date, start_date: @event.start_date, title: @event.title } }
+    assert_redirected_to event_url(@event)
+  end
+
+  test "should destroy event" do
+    assert_difference('Event.count', -1) do
+      delete event_url(@event)
+    end
+
+    assert_redirected_to events_url
+  end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyString
+  description: MyText
+  start_date: 2019-12-27 07:25:26
+  end_date: 2019-12-27 07:25:26
+
+two:
+  title: MyString
+  description: MyText
+  start_date: 2019-12-27 07:25:26
+  end_date: 2019-12-27 07:25:26

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -1,0 +1,49 @@
+require "application_system_test_case"
+
+class EventsTest < ApplicationSystemTestCase
+  setup do
+    @event = events(:one)
+  end
+
+  test "visiting the index" do
+    visit events_url
+    assert_selector "h1", text: "Events"
+  end
+
+  test "creating a Event" do
+    visit events_url
+    click_on "New Event"
+
+    fill_in "Description", with: @event.description
+    fill_in "End date", with: @event.end_date
+    fill_in "Start date", with: @event.start_date
+    fill_in "Title", with: @event.title
+    click_on "Create Event"
+
+    assert_text "Event was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Event" do
+    visit events_url
+    click_on "Edit", match: :first
+
+    fill_in "Description", with: @event.description
+    fill_in "End date", with: @event.end_date
+    fill_in "Start date", with: @event.start_date
+    fill_in "Title", with: @event.title
+    click_on "Update Event"
+
+    assert_text "Event was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Event" do
+    visit events_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Event was successfully destroyed"
+  end
+end


### PR DESCRIPTION
# 概要（what?）
ユーザー（アルバイト）がログイン後に表示される画面の機能追加。
### 画像イメージ
<img width="737" alt="スクリーンショット 2019-12-27 15 16 15" src="https://user-images.githubusercontent.com/54671960/71504207-dffb3880-28bb-11ea-9e75-56d5682c36bd.png">


# 目的(why?)
カレンダー表の作成。

# 追加内容
<img width="1256" alt="スクリーンショット 2019-12-27 20 13 41" src="https://user-images.githubusercontent.com/54671960/71515177-67a96d00-28e5-11ea-8c6f-bced0220ba8d.png">
・full calendarを使用


### 注意事項
フルスクリーン状態で１月分のカレンダー表示のサイズに変更する
（このままだとカレンダーのサイズが大きすぎるので）

