### PR TITLE
Feature/fixed design of user index

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,2 @@
 //= require_tree .
 //= require materialize-sprockets
-document.addEventListener("DOMContentLoaded", function() {
-  var elems = document.querySelectorAll("select");
-  var instances = M.FormSelect.init(elems, options);
-});

--- a/app/views/user/index.html.erb
+++ b/app/views/user/index.html.erb
@@ -1,14 +1,25 @@
-<h1>ユーザー一覧</h1>
-
-<div class="row">
+<body>
+  <div class="container">
+    <!--titile-->
+    <div class='row center'>
+      <div class='col s12'>
+        <h2>ユーザー一覧</h2>
+      </div>
+    </div>
+    <!--content-->
+    <div class="row">
     <% @users.each do |user|%>
-        <div class="col s12 m6">
-            <div class="card blue accent-2">
-                <div class="card-content white-text">
-                    <span class="card-title"><%= user.name%></>
-                    <p><%= user.profile%></p>
-                </div>
-            </div>
+    <div class="col s12 m12">
+      <div class="card light-blue accent-1">
+        <div class="card-content white-text">
+          <span class="card-title"><i class="medium material-icons center">account_box</i><%= user.name%></span>
+          <p><%= user.profile%></p>
         </div>
+      </div>
+    </div>
     <% end %>
   </div>
+
+
+  </div>
+</body>


### PR DESCRIPTION
# 目的（why?）
- ユーザー一覧でレイアウトを統一
（プロフィールコメントを書いている・書いていないでレイアウトが崩れいている。）

# 何を作ったのか？(what?)
### before
<img width="1280" alt="スクリーンショット 2020-02-16 0 03 22" src="https://user-images.githubusercontent.com/54671960/74590266-4b59bf00-5050-11ea-8a73-1a317214c312.png">

### after
<img width="909" alt="スクリーンショット 2020-02-16 0 03 38" src="https://user-images.githubusercontent.com/54671960/74590269-4eed4600-5050-11ea-91b3-319b9d31e438.png">

- materializeでレイアウトの見直し